### PR TITLE
Fix variable declaration typo

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ if (mongoURL == null && process.env.DATABASE_SERVICE_NAME) {
       mongoHost = process.env[mongoServiceName + '_SERVICE_HOST'],
       mongoPort = process.env[mongoServiceName + '_SERVICE_PORT'],
       mongoDatabase = process.env[mongoServiceName + '_DATABASE'],
-      mongoPassword = process.env[mongoServiceName + '_PASSWORD']
+      mongoPassword = process.env[mongoServiceName + '_PASSWORD'],
       mongoUser = process.env[mongoServiceName + '_USER'];
 
   if (mongoHost && mongoPort && mongoDatabase) {


### PR DESCRIPTION
## Summary
- fix missing comma in MongoDB service environment variable assignment

## Testing
- `npm test` *(fails: `mocha: not found`)*